### PR TITLE
move sleep for ton client to use it only when we are up to date with …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0]
+- Move timeout between blocks for TON outside of shards logic
+    - Before
+        - We had a delay between all the shards of master block
+    - Now
+        - We well have a delay only when our latest block is bigger to network latests (we are up to date)
+    It should speed up TON block monitoring but you know will get 429 limits on free tiers for sure
+    Maybe later more variables will be added to cover TON network monitoring
+
 ## [5.1.0]
 - revert all the changes from 5.0.0
 

--- a/aiotx/clients/_ton_base_client.py
+++ b/aiotx/clients/_ton_base_client.py
@@ -420,10 +420,10 @@ class TonMonitor(BlockMonitor):
             self.client.workchain = workchain
         target_block = seqno if self._latest_block is None else self._latest_block
         if target_block > seqno:
+            await asyncio.sleep(timeout_between_blocks)
             return
         shards = await self.client.get_master_block_shards(target_block)
         for shard in shards:
-            await asyncio.sleep(timeout_between_blocks)
             shard_transactions = await self.client.get_block_transactions(
                 shard["workchain"], shard["shard"], shard["seqno"], 1000
             )

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -66,8 +66,6 @@ If no starting block is provided, monitoring will start from the latest block.
 You can also use the `timeout_between_blocks` param to choose how much time monitoring should wait to try get new block.
 For BTC, for example, we can wait 5-10 seconds and it's fine, but for TON we should wait <1 second.
 
-In TON, `timeout_between_blocks` will also be used as timeout between getting shards for master block to prevent 429 error.
-
 `timeout_between_blocks` is optional and set to 1 second by default.
 
     - **monitoring_start_block** (int, optional): Block number from which to begin monitoring.


### PR DESCRIPTION
- Move timeout between blocks for TON outside of shards logic
    - Before
        - We had a delay between all the shards of master block
    - Now
        - We well have a delay only when our latest block is bigger to network latests (we are up to date)
    It should speed up TON block monitoring but you know will get 429 limits on free tiers for sure
    Maybe later more variables will be added to cover TON network monitoring